### PR TITLE
fix: prevent `bullet.gd` error using `call_deferred`

### DIFF
--- a/scripts/bullet.gd
+++ b/scripts/bullet.gd
@@ -26,8 +26,7 @@ func _on_body_entered(body: Node2D) -> void:
 		explosion.global_position = global_position
 		explosion.team = team
 		explosion.effects = effects
-		get_parent().add_child(explosion) # TODO: fix this line's error
-		explosion.explode()
+		call_deferred("add_sibling", explosion)
 
 		if lives.try_die():
 			queue_free()

--- a/scripts/explosion.gd
+++ b/scripts/explosion.gd
@@ -4,6 +4,11 @@ extends Area2D
 var team: String
 var effects: Array[EffectBase] = []
 
+
+func _enter_tree() -> void:
+	call_deferred("explode")
+
+
 func explode() -> void:
 	$AnimatedSprite2D.play("default")
 	$AudioStreamPlayer.play()
@@ -19,4 +24,3 @@ func explode() -> void:
 	
 	await $AnimatedSprite2D.animation_finished
 	queue_free()
-	


### PR DESCRIPTION
- Additionally move call to `explode()` into `explosion.gd`