### PR TITLE
ci: run action on PR edit

### DIFF
--- a/.github/workflows/verify-develop.yml
+++ b/.github/workflows/verify-develop.yml
@@ -5,6 +5,7 @@ on:
   # Triggers the workflow on pull request events but only for the "dev" branch
   pull_request:
     branches: ["dev"]
+    types: [opened, synchronize, reopened, edited]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Allow actions to run when PR is modified, e.g. when the base branch is changed.